### PR TITLE
Added a few touchups in terms of input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,12 @@ use nmuidi::nmuidi::Cleaner;
 use std::{env, time::Instant};
 
 fn main() {
+
+    if env::args().len() < 2 {
+        println!("Usage: nmuidi <dir>");
+        return;
+    }
+
     pretty_env_logger::init();
 
     let mut directory_timings = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,31 +3,44 @@ use nmuidi::nmuidi::Cleaner;
 use std::{env, time::Instant};
 
 fn main() {
+    if env::args().len() == 2 {
+        println!("Are you sure you want to delete the files in the directory? (y/N)");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).unwrap();
+        if input.trim() != "y" {
+            println!("Exiting...");
+            return;
+        }
+    } else if env::args().len() == 3 {
+        if env::args().nth(2).unwrap() != "-y" {
+            println!("Usage: nmuidi <dir> (-y)");
+            return;
+        } else {
+            println!("Deleting without confirmation...");
+            pretty_env_logger::init();
 
-    if env::args().len() < 2 {
-        println!("Usage: nmuidi <dir>");
+            let mut directory_timings = Vec::new();
+            let start_time = Instant::now();
+            for dir in env::args().skip(1) {
+                println!("Cleaning {dir}");
+                let start = Instant::now();
+
+                Cleaner::new(&dir).clean();
+                directory_timings.push((dir, start.elapsed()));
+            }
+
+            let elapsed_time = start_time.elapsed();
+            debug!("Total time: {:.2?}", elapsed_time);
+            debug!("Directory timings:");
+            for (dir, time_spent) in directory_timings {
+                debug!("  dir {dir} took {:.2?}", time_spent);
+            }
+            trace!("Done.");
+        }
+    } else {
+        println!("Usage: nmuidi <dir> (-y)");
         return;
     }
-
-    pretty_env_logger::init();
-
-    let mut directory_timings = Vec::new();
-    let start_time = Instant::now();
-    for dir in env::args().skip(1) {
-        println!("Cleaning {dir}");
-        let start = Instant::now();
-
-        Cleaner::new(&dir).clean();
-        directory_timings.push((dir, start.elapsed()));
-    }
-
-    let elapsed_time = start_time.elapsed();
-    debug!("Total time: {:.2?}", elapsed_time);
-    debug!("Directory timings:");
-    for (dir, time_spent) in directory_timings {
-        debug!("  dir {dir} took {:.2?}", time_spent);
-    }
-    trace!("Done.");
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,44 +3,50 @@ use nmuidi::nmuidi::Cleaner;
 use std::{env, time::Instant};
 
 fn main() {
-    if env::args().len() == 2 {
-        println!("Are you sure you want to delete the files in the directory? (y/N)");
+    if env::args().any(|arg| arg == "-h") {
+        println!("Usage: nmuidi <dir> [dirs...] (-y)");
+        return;
+    }
+    
+    if env::args().last().unwrap() == "-y" {
+        println!("Deleting without confirmation...");
+        clean();
+    } else {
+        println!("Are you sure you want to delete the folder and everything inside of it? (y/N)");
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();
-        if input.trim() != "y" {
+        if input.trim() == "y" {
+            clean();
+        } else {
             println!("Exiting...");
             return;
         }
-    } else if env::args().len() == 3 {
-        if env::args().nth(2).unwrap() != "-y" {
-            println!("Usage: nmuidi <dir> (-y)");
-            return;
-        } else {
-            println!("Deleting without confirmation...");
-            pretty_env_logger::init();
-
-            let mut directory_timings = Vec::new();
-            let start_time = Instant::now();
-            for dir in env::args().skip(1) {
-                println!("Cleaning {dir}");
-                let start = Instant::now();
-
-                Cleaner::new(&dir).clean();
-                directory_timings.push((dir, start.elapsed()));
-            }
-
-            let elapsed_time = start_time.elapsed();
-            debug!("Total time: {:.2?}", elapsed_time);
-            debug!("Directory timings:");
-            for (dir, time_spent) in directory_timings {
-                debug!("  dir {dir} took {:.2?}", time_spent);
-            }
-            trace!("Done.");
-        }
-    } else {
-        println!("Usage: nmuidi <dir> (-y)");
-        return;
     }
+}
+
+fn clean() {
+    pretty_env_logger::init();
+
+    let mut directory_timings = Vec::new();
+    let start_time = Instant::now();
+    for dir in env::args().skip(1) {
+        if dir == "-y" {
+            continue;
+        }
+        println!("Cleaning {dir}");
+        let start = Instant::now();
+
+        Cleaner::new(&dir).clean();
+        directory_timings.push((dir, start.elapsed()));
+    }
+
+    let elapsed_time = start_time.elapsed();
+    debug!("Total time: {:.2?}", elapsed_time);
+    debug!("Directory timings:");
+    for (dir, time_spent) in directory_timings {
+        debug!("  dir {dir} took {:.2?}", time_spent);
+    }
+    trace!("Done.");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Changes
- Added usage text:
```
"Usage: nmuidi <dir> (-y)"
```
- Added passing argument -y to skip confirmation. This was motivated by the README saying that the program doesn't confirm and from the default rm command output in Powershell:
```
Confirm
The item at C:\Users\MemoryHunter\Desktop\New folder\ has children and the Recurse parameter was not specified. If you
continue, all children will be removed with the item. Are you sure you want to continue?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
```
as this requires confirmation, thought since this was meant to speed up operations on Windows, it deserves the same sort of behaviour as the rm in Powershell.

## What to improve
I am not quite sure how to add tests properly for the behaviours I added, so that's needed.