### PR TITLE
Add crate documentation via docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nmuidi"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Parallelizes deleting directories which can significantly speed up deleting large deeply nested directories with a large number of files on Windows"
 readme = "README.md"
 homepage = "https://github.com/Dillonb/nmuidi"
-documentation = "https://github.com/Dillonb/nmuidi"
+documentation = "https://docs.rs/nmuidi"
 repository = "https://github.com/Dillonb/nmuidi"
 license = "MIT"
 keywords = ["windows", "delete", "parallel"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,38 @@
-pub mod nmuidi;
+//! Deletes stuff, hopefully quickly
+//!
+//! ## Installation
+//! - [Download for Windows](https://nightly.link/Dillonb/nmuidi/workflows/build/main/nmuidi-windows.zip)
+//! - Or just use `cargo`
+//!
+//! ## Benchmarks
+//! - [This video](https://www.youtube.com/watch?v=G8BdXgBdaOA) benchmarks several popular suggestions for deleting files quickly on Windows and compares them to nmuidi.
+//!
+//! ## How to use
+//! ### As a command-line tool
+//! - You can download using the link above. The easiest way to use it in Windows is to make a folder (something like `C:\bin`)
+//! - Add that folder to your path
+//! - Then add `nmuidi.exe` file you downloaded to that folder and restart any terminals you have open
+//!
+//! Then you can run `nmuidi /path/to/some/dir` and you should see some output like the following:
+//! ```PS
+//! → ~\repos\nmuidi [main ≡ +0 ~1 -0 !]› nmuidi test
+//! Cleaning test
+//! ```
+//!
+//! ### As a library
+//! ```
+//! use nmuidi::prelude::*;
+//!
+//! let dir = "path/to/something";
+//! Cleaner::new(dir).clean();
+//! ```
+//!
 
+/// All nmuidi `Cleaner` functionality
 pub mod prelude {
     pub use crate::nmuidi::Cleaner;
 }
+
+/// Module containing basic libray functionality
+#[doc(hidden)]
+pub mod nmuidi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use log::{debug, trace};
-use nmuidi::nmuidi::Cleaner;
+#[doc(inline)]
+use nmuidi::prelude::*;
 use std::{env, time::Instant};
 
 fn main() {

--- a/src/nmuidi.rs
+++ b/src/nmuidi.rs
@@ -1,14 +1,18 @@
 use std::{fs, path::PathBuf};
 
 use itertools::Itertools;
-
 use jwalk::{
     rayon::prelude::{IntoParallelRefIterator, ParallelBridge, ParallelIterator},
     WalkDir,
 };
-
 use log::error;
 
+/// `Cleaner` is a lazily executed framework for nmuidi.
+/// # Examples
+/// ```
+/// use nmuidi::prelude::*;
+/// let cleaner = Cleaner::new("some/path").clean();
+/// ```
 pub struct Cleaner {
     path: PathBuf,
     dirs: Vec<(PathBuf, usize)>, // (path, depth)
@@ -16,6 +20,7 @@ pub struct Cleaner {
 }
 
 impl Cleaner {
+    /// Form a new `Cleaner` stuct, does not execute anything until `.clean()` is called
     pub fn new<T>(path: T) -> Self
     where
         std::path::PathBuf: std::convert::From<T>,
@@ -27,6 +32,7 @@ impl Cleaner {
         }
     }
 
+    /// Perform the deletion of the selected directory
     pub fn clean(&mut self) {
         self.remove_files();
         self.remove_dirs();


### PR DESCRIPTION
I converted some of the README.md to the cargo docs format. 

To support the switch I also:
- Bumped a minor version so a new docs.rs page will be built when it is published
- Changed the docs link to docs.rs
- Added some doc tests/examples

Please let me know if you have any questions/concerns. The new video was great by the way, glad the findings were positive but also saddened at Microsoft's incompetence. 